### PR TITLE
Allow \x26 as ampersand.

### DIFF
--- a/test/_assets/minification/ku.js.correct
+++ b/test/_assets/minification/ku.js.correct
@@ -1,1 +1,1 @@
-﻿CKEDITOR.plugins.setLang("about","ku",{copy:"مافی لەبەرگەرتنەوەی &copy; $1. گشتی پارێزراوه.",dlgTitle:"دەربارەی CKEditor",help:"سەیری $1 بکه بۆ یارمەتی.",moreInfo:"بۆ زانیاری زیاتری مۆڵەت, تکایه سەردانی ماڵپەڕەکەمان بکه:",title:"دەربارەی CKEditor",userGuide:"ڕێپیشاندەری CKEditors"});
+﻿CKEDITOR.plugins.setLang("about","ku",{copy:"مافی لەبەرگەرتنەوەی \x26copy; $1. گشتی پارێزراوه.",dlgTitle:"دەربارەی CKEditor",help:"سەیری $1 بکه بۆ یارمەتی.",moreInfo:"بۆ زانیاری زیاتری مۆڵەت, تکایه سەردانی ماڵپەڕەکەمان بکه:",title:"دەربارەی CKEditor",userGuide:"ڕێپیشاندەری CKEditors"});


### PR DESCRIPTION
Changing the test, becuase in JS "\x26" is an escaped ampersand and within a JS String it is evaluated as such. #14 