### PR TITLE
Stub the timestamp for all tests.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ CKBuilder.options.debug = 2;
 	var assetsDir = new File( assetsPath );
 	var tempPath = 'test/tmp';
 	var tempDir = new File( tempPath );
-	var timestampStub = 'G3KH';
+	CKBuilder.options.timestamp = 'G3KH'; // Stub the timestamp.
 
 	function isArray(o) {
 		return Object.prototype.toString.call(o) === '[object Array]';
@@ -202,18 +202,8 @@ CKBuilder.options.debug = 2;
 
 		var imageFile = new File( tempPath + "/sprite/icons.png" );
 		var cssFile = new File( tempPath + "/sprite/icons.css" );
-		var originalTimestamp = CKBuilder.options.timestamp;
 
-		CKBuilder.options.timestamp = timestampStub;
-
-		try {
-			CKBuilder.image.createFullSprite( pluginsLocation, skinLocation, imageFile, cssFile, plugins );
-		} catch ( e ) {
-			// In any case restore timestamp.
-			CKBuilder.options.timestamp = originalTimestamp;
-			// And rethrow the exception.
-			throw e;
-		}
+		CKBuilder.image.createFullSprite( pluginsLocation, skinLocation, imageFile, cssFile, plugins );
 
 		assertEquals( CKBuilder.io.readFile( new File( assetsDir, "/sprite/icons.correct.css" ) ), CKBuilder.io.readFile( cssFile ),
 			'Checking content of icons.css' );
@@ -255,13 +245,7 @@ CKBuilder.options.debug = 2;
 		var imageFile = new File( tempPath + "/sprite/icons3.png" );
 		var cssFile = new File( tempPath + "/sprite/icons3.css" );
 
-		CKBuilder.options.timestamp = timestampStub;
-		try {
-			CKBuilder.image.createFullSprite( pluginsLocation, skinLocation, imageFile, cssFile, plugins, true );
-		} catch ( e ) {
-			CKBuilder.options.timestamp = originalTimestamp;
-			throw e;
-		}
+		CKBuilder.image.createFullSprite( pluginsLocation, skinLocation, imageFile, cssFile, plugins, true );
 
 		assertEquals( CKBuilder.io.readFile( new File( assetsDir, "/sprite/icons3.correct.css" ) ), CKBuilder.io.readFile( cssFile ),
 			'Checking content of icons3.css' );
@@ -530,29 +514,22 @@ CKBuilder.options.debug = 2;
 		var originalTimestamp = CKBuilder.options.timestamp;
 
 		// Stub the timestamp.
-		CKBuilder.options.timestamp = timestampStub;
 		CKBuilder.options.leaveCssUnminified = true;
 		var sourceLocation = new File( assetsDir, 'skins/kama' );
 		var correctResultLocation = new File( assetsDir, 'skins/kama_correct' );
 		var targetLocation = new File( tempDir, 'skins/kama' );
 
-		try {
-			CKBuilder.skin.build( sourceLocation, targetLocation );
-			assertDirectoriesAreEqual( correctResultLocation, targetLocation, 'Checking skin builder (CSS minification disabled)' );
+		CKBuilder.skin.build( sourceLocation, targetLocation );
+		assertDirectoriesAreEqual( correctResultLocation, targetLocation, 'Checking skin builder (CSS minification disabled)' );
 
-			CKBuilder.options.leaveCssUnminified = false;
-			var sourceLocation = new File( assetsDir, 'skins_minified/kama' );
-			var correctResultLocation = new File( assetsDir, 'skins_minified/kama_correct' );
-			var targetLocation = new File( tempDir, 'skins_minified/kama' );
+		CKBuilder.options.leaveCssUnminified = false;
+		var sourceLocation = new File( assetsDir, 'skins_minified/kama' );
+		var correctResultLocation = new File( assetsDir, 'skins_minified/kama_correct' );
+		var targetLocation = new File( tempDir, 'skins_minified/kama' );
 
-			CKBuilder.skin.build( sourceLocation, targetLocation );
-			assertDirectoriesAreEqual( correctResultLocation, targetLocation, 'Checking skin builder (CSS minification enabled)' );
-		} catch ( e ) {
-			// In any case restore timestamp.
-			CKBuilder.options.timestamp = originalTimestamp;
-			// And rethrow the exception.
-			throw e;
-		}
+		CKBuilder.skin.build( sourceLocation, targetLocation );
+		assertDirectoriesAreEqual( correctResultLocation, targetLocation, 'Checking skin builder (CSS minification enabled)' );
+
 	}
 
 	function testVerifyPlugins()


### PR DESCRIPTION
As it turns out we can stub the timestamp for all tests with no adverse consequences. #17