### PR TITLE
Add new parameter for including extra plugin in build

### DIFF
--- a/src/lib/builder.js
+++ b/src/lib/builder.js
@@ -295,16 +295,39 @@ CKBuilder.builder = function( srcDir, dstDir ) {
 	 */
 	function filterPluginFolders() {
 		var pluginsFolder = new File( targetLocation, 'plugins' );
+
 		if ( !pluginsFolder.exists() )
 			return;
-		var dirList = pluginsFolder.list();
+
+		var requiredPlugins = CKBuilder.options.requirePlugins ? CKBuilder.options.requirePlugins.split( ',' ) : [],
+			dirList = pluginsFolder.list();
+
 		for ( var i = 0; i < dirList.length; i++ ) {
-			if ( !pluginNames[ dirList[ i ] ] && dirList[ i ] != CKBuilder.options.requirePlugin ) {
+			if ( !pluginNames[ dirList[ i ] ] && !includes( requiredPlugins, dirList[ i ] ) ) {
 				if ( CKBuilder.options.debug > 1 )
 					print( 'Removing unused plugin: ' + dirList[ i ] );
 				CKBuilder.io.deleteDirectory( File( pluginsFolder, dirList[ i ] ) );
 			}
 		}
+	}
+
+	/**
+	 * Check if an array contains given element.
+	 * Alias for Array.prototype.includes method.
+	 *
+	 * @param {Array} array
+	 * @param {String} element
+	 *
+	 * @returns {Boolean}
+	 */
+	function includes( array, element ) {
+		for ( var i = 0; i < array.length; i++ ) {
+			if ( array[ i ] == element ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/lib/builder.js
+++ b/src/lib/builder.js
@@ -299,7 +299,7 @@ CKBuilder.builder = function( srcDir, dstDir ) {
 			return;
 		var dirList = pluginsFolder.list();
 		for ( var i = 0; i < dirList.length; i++ ) {
-			if ( !pluginNames[ dirList[ i ] ] ) {
+			if ( !pluginNames[ dirList[ i ] ] && dirList[ i ] != CKBuilder.options.requirePlugin ) {
 				if ( CKBuilder.options.debug > 1 )
 					print( 'Removing unused plugin: ' + dirList[ i ] );
 				CKBuilder.io.deleteDirectory( File( pluginsFolder, dirList[ i ] ) );

--- a/src/lib/controller.js
+++ b/src/lib/controller.js
@@ -46,7 +46,7 @@ CKBuilder.Controller = function() {
 		[ null, "commercial", false, "builds a package with commercial license" ],
 		[ null, "name", [ "NAME", "expected name" ], "the expected name of the skin/plugin, used for verification" ],
 		[ "d", "debug-level", [ "LEVEL", "debug level (0, 1, 2)." ], "sets the debug level" ],
-		[ "r", "require-plugins", [ "NAME", "plugin names" ], "target plugin will not be removed from the build even if it isn't used" ]
+		[ "r", "require-plugins", [ "NAMES", "plugin names" ], "target plugin will be added to the output build directory in minified version" ]
 	];
 
 	/**

--- a/src/lib/controller.js
+++ b/src/lib/controller.js
@@ -46,7 +46,7 @@ CKBuilder.Controller = function() {
 		[ null, "commercial", false, "builds a package with commercial license" ],
 		[ null, "name", [ "NAME", "expected name" ], "the expected name of the skin/plugin, used for verification" ],
 		[ "d", "debug-level", [ "LEVEL", "debug level (0, 1, 2)." ], "sets the debug level" ],
-		[ "r", "require-plugin", [ "NAME", "plugin name" ], "target plugin will not be removed from the build even if it isn't used" ]
+		[ "r", "require-plugins", [ "NAME", "plugin names" ], "target plugin will not be removed from the build even if it isn't used" ]
 	];
 
 	/**
@@ -223,8 +223,8 @@ CKBuilder.Controller.prototype = {
 		if ( line.hasOption( "no-tar" ) )
 			CKBuilder.options.noTar = true;
 
-		if ( line.hasOption( "require-plugin" ) )
-			CKBuilder.options.requirePlugin = line.getOptionValue( "require-plugin" );
+		if ( line.hasOption( "require-plugins" ) )
+			CKBuilder.options.requirePlugins = line.getOptionValue( "require-plugins" );
 
 		var foundCommandName = null;
 		for ( var commandName in this.commandsHandlers ) {

--- a/src/lib/controller.js
+++ b/src/lib/controller.js
@@ -46,7 +46,7 @@ CKBuilder.Controller = function() {
 		[ null, "commercial", false, "builds a package with commercial license" ],
 		[ null, "name", [ "NAME", "expected name" ], "the expected name of the skin/plugin, used for verification" ],
 		[ "d", "debug-level", [ "LEVEL", "debug level (0, 1, 2)." ], "sets the debug level" ],
-		[ "r", "require-plugins", [ "NAMES", "plugin names" ], "target plugin will be added to the output build directory in minified version" ]
+		[ "r", "require-plugins", [ "NAMES", "plugin names" ], "target plugins will be added to the output build directory in a minified version (but without their dependencies)" ]
 	];
 
 	/**

--- a/src/lib/controller.js
+++ b/src/lib/controller.js
@@ -45,7 +45,8 @@ CKBuilder.Controller = function() {
 		[ null, "core", false, "build only the core file (ckeditor.js)" ],
 		[ null, "commercial", false, "builds a package with commercial license" ],
 		[ null, "name", [ "NAME", "expected name" ], "the expected name of the skin/plugin, used for verification" ],
-		[ "d", "debug-level", [ "LEVEL", "debug level (0, 1, 2)." ], "sets the debug level" ]
+		[ "d", "debug-level", [ "LEVEL", "debug level (0, 1, 2)." ], "sets the debug level" ],
+		[ "r", "require-plugin", [ "NAME", "plugin name" ], "target plugin will not be removed from the build even if it isn't used" ]
 	];
 
 	/**
@@ -221,6 +222,9 @@ CKBuilder.Controller.prototype = {
 
 		if ( line.hasOption( "no-tar" ) )
 			CKBuilder.options.noTar = true;
+
+		if ( line.hasOption( "require-plugin" ) )
+			CKBuilder.options.requirePlugin = line.getOptionValue( "require-plugin" );
 
 		var foundCommandName = null;
 		for ( var commandName in this.commandsHandlers ) {


### PR DESCRIPTION
To test:
- build a `ckbuilder.jar` file (requires `ant` installed).
- go to `ckeditor4-presets` repo.
- change `build.sh` file to use the local `ckbuilder.jar` file.

Closes #29.